### PR TITLE
Fix code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/tlsreader.js
+++ b/tlsreader.js
@@ -1,5 +1,5 @@
 const tls = require('tls');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 
 function getTlsResults(hostname) {
     return new Promise((resolve, reject) => {
@@ -78,9 +78,9 @@ function getTlsResults(hostname) {
 
                     ciphers.forEach(cipher => {
                         const tlsVersionFlag = cipher.startsWith('TLS_') ? '-tls1_3' : '-tls1_2';
-                        const command = `openssl s_client -connect ${hostname}:${port} -cipher '${cipher}' ${tlsVersionFlag} < /dev/null`;
+                        const args = ['s_client', '-connect', `${hostname}:${port}`, '-cipher', cipher, tlsVersionFlag, '<', '/dev/null'];
 
-                        exec(command, (error, stdout, stderr) => {
+                        execFile('openssl', args, (error, stdout, stderr) => {
                             // Parse the stdout to check if the cipher was successful
                             const cipherRegex = /Cipher\s*:\s*(.*)/;
                             const match = stdout.match(cipherRegex);


### PR DESCRIPTION
Fixes [https://github.com/shakerg/tlsreader/security/code-scanning/1](https://github.com/shakerg/tlsreader/security/code-scanning/1)

To fix the problem, we should avoid using `exec` with a concatenated command string that includes user input. Instead, we can use `execFile` or `execFileSync`, which allows us to pass the command and its arguments as separate parameters, thus avoiding the risk of command injection. This approach ensures that the user input is treated as a single argument and not as part of the command line.

In this case, we will replace the `exec` call with `execFile` and pass the hostname and other parameters as separate arguments. This change will be made in the `tlsreader.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
